### PR TITLE
fix: add Next.js API proxy route to avoid mixed content

### DIFF
--- a/frontend/app/api/changelog/route.ts
+++ b/frontend/app/api/changelog/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  const res = await fetch(`${process.env.API_URL}/api/changelog`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text }, { status: res.status });
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/frontend/env.example
+++ b/frontend/env.example
@@ -1,0 +1,1 @@
+API_URL=http://localhost:8081

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -5,7 +5,7 @@ export async function generateChangelog(payload: {
   to_tag?: string;
   format: "markdown" | "plaintext";
 }) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/changelog`, {
+  const res = await fetch("/api/changelog", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),


### PR DESCRIPTION
## What does this PR do?
Adds a Next.js API proxy route so the frontend never calls the Oracle backend directly. The browser hits /api/changelog on Vercel (HTTPS), Vercel's server forwards it to the backend (HTTP). Fixes the mixed content error in production.

## What changed?
- Frontend

## How did you test it?
Build passes. Tested locally against the backend.